### PR TITLE
Fix Release Asset Upload Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Upload `.mez` as release asset
       uses: softprops/action-gh-release@v1
       with:
-        files: bin\AnyCPU\Release\enlyze-powerbi.mez
+        files: bin/AnyCPU/Release/enlyze-powerbi.mez
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR makes the Release Asset Upload GH Action work. 

Trivia: The action requires you to use unix path notation (`/` vs windows `\`) although you are on windows. [Link](https://github.com/softprops/action-gh-release#:~:text=%E2%9A%A0%EF%B8%8F-,Note,-for%20Windows%3A)