### PR TITLE
Add connection test to enable running on PowerBI Gateway

### DIFF
--- a/ApiClient.pqm
+++ b/ApiClient.pqm
@@ -21,7 +21,15 @@ let
             queryParamsNonNull = Record.RemoveFields(combinedQueryParams, nullValueFields),
             queryString = Uri.BuildQueryString(queryParamsNonNull),
             apiUrlWithQueryParams = if Text.Length(queryString) > 0 then apiUrl & "?" & queryString else apiUrl,
-            parsedResponse = Json.Document(Web.Contents(apiUrlWithQueryParams, [Headers = headers]))
+            response = Web.Contents(
+                apiUrlWithQueryParams, [Headers = headers, ManualStatusHandling = {400, 401, 403, 404, 422, 500}]
+            ),
+            statusCode = Value.Metadata(response)[Response.Status],
+            parsedResponse =
+                if statusCode = 200 then
+                    Json.Document(response)
+                else
+                    error "HTTP Error: " & Text.From(statusCode) & ". Response body: " & Text.FromBinary(response)
         in
             parsedResponse,
     FetchPaginated = (apiPath as text, cursor as nullable text, optional queryParams as nullable record) as list =>

--- a/ApiClient.pqm
+++ b/ApiClient.pqm
@@ -22,7 +22,7 @@ let
             queryString = Uri.BuildQueryString(queryParamsNonNull),
             apiUrlWithQueryParams = if Text.Length(queryString) > 0 then apiUrl & "?" & queryString else apiUrl,
             response = Web.Contents(
-                apiUrlWithQueryParams, [Headers = headers, ManualStatusHandling = {400, 401, 403, 404, 422, 500}]
+                apiUrlWithQueryParams, [Headers = headers, ManualStatusHandling = {400, 401, 403, 404, 422, 500, 503}]
             ),
             statusCode = Value.Metadata(response)[Response.Status],
             parsedResponse =

--- a/enlyze.pq
+++ b/enlyze.pq
@@ -101,6 +101,8 @@ shared enlyze.Contents = () =>
     in
         NavTable;
 
+shared enlyze.ConnectionTest = () => enlyze.Contents(){[Key = "sites"]}[Data];
+
 enlyze = [
     Authentication = [
         Key = [
@@ -108,7 +110,8 @@ enlyze = [
             KeyLabel = "ENLYZE API Key"
         ]
     ],
-    Label = "ENLYZE"
+    Label = "ENLYZE",
+    TestConnection = (dataSourcePath) => {"enlyze.ConnectionTest"}
 ];
 
 enlyze.Publish = [


### PR DESCRIPTION
Turns out that a connection test [is mandatory](https://github.com/microsoft/DataConnectors/blob/9fb5c1d748bdd5f7ba92bc035564da9a97fd8fef/samples/OData/AnnotationsSample/AnnotationsSample.pq#L6-L7) in order to run a custom connector on a PowerBI Gateway.

This PR introduces a connection test by loading Sites.

Closes
* https://github.com/enlyze/enlyze-powerbi/issues/20